### PR TITLE
chore(readme): fix multiple issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: ChristophWurst/conventional-nextcloud-npm-release@v1
+      - uses: ChristophWurst/conventional-nextcloud-npm-release@v1.0.0
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
     environment: npm registry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: ChristophWurst/conventional-nextcloud-npm-release@v1.0.0
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The workflow can't be run because `v1` can't be found.

Ref https://github.com/nextcloud/calendar-js/actions/runs/6768510241/job/18393084263