### PR TITLE
feat: implement npm-tag input to specify a tag to push to

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   npm-token:
     description: 'Npm registry auth token'
     required: true
+  npm-tag:
+    description: 'Npm tag to publish to'
+    required: false
+    default: 'latest'
 runs:
   using: "composite"
   steps:
@@ -68,6 +72,6 @@ runs:
     - name: Publish package
       if: ${{ steps.changelog.outputs.skipped == 'false' }}
       shell: bash
-      run: npm publish
+      run: npm publish --tag=${{ inputs.npm-tag }}
       env:
         NODE_AUTH_TOKEN: ${{ inputs.npm-token }}


### PR DESCRIPTION
This is handy when maintaining multiple stable branches of a library. We can then set `npm-tag` to `stableX` in the workflow file of the corresponding branch. The release workflow will then push the stable tag instead of overwriting the latest tag with an old one all the time.

The latest tag is also the one that will be shown on the front page and will be installed by default if no tag is specified, for example, `npm install foo-bar` vs. `npm install foo-bar@latest` or `npm install foo-bar@stableX`.

Ref `npm help publish` for the default value (`latest`)